### PR TITLE
Update versions.tf for AWS provider upgrade

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -1,6 +1,6 @@
 module "eks" {
-  source          = "terraform-aws-modules/eks/aws"
-  version         = "20.8.4"
+  source  = "terraform-aws-modules/eks/aws"
+  version = "21.0.0"
   cluster_name    = local.cluster_name
   cluster_version = var.kubernetes_version
   subnet_ids      = module.vpc.private_subnets

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -1,31 +1,38 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "21.0.0"
+
   cluster_name    = local.cluster_name
   cluster_version = var.kubernetes_version
-  subnet_ids      = module.vpc.private_subnets
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
 
   enable_irsa = true
+
+  cluster_addons = {
+    coredns = { most_recent = true }
+    kube-proxy = { most_recent = true }
+    vpc-cni = { most_recent = true }
+  }
+
+  eks_managed_node_groups = {
+    node_group = {
+      ami_type        = "AL2_x86_64"
+      instance_types  = ["t3.medium"]
+
+      min_size     = 2
+      max_size     = 6
+      desired_size = 2
+
+      attach_cluster_primary_security_group = false
+      vpc_security_group_ids = [
+        aws_security_group.all_worker_mgmt.id
+      ]
+    }
+  }
 
   tags = {
     cluster = "demo"
   }
-
-  vpc_id = module.vpc.vpc_id
-
-  eks_managed_node_group_defaults = {
-    ami_type               = "AL2_x86_64"
-    instance_types         = ["t3.medium"]
-    vpc_security_group_ids = [aws_security_group.all_worker_mgmt.id]
-  }
-
-  eks_managed_node_groups = {
-
-    node_group = {
-      min_size     = 2
-      max_size     = 6
-      desired_size = 2
-    }
-  }
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,27 +1,25 @@
-
 terraform {
-  required_version = ">= 0.12"
   required_providers {
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.1.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">=2.7.1"
-    }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.68.0"
+      version = ">= 5.40.0"
     }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.7.1"
+    }
+
     local = {
       source  = "hashicorp/local"
       version = "~> 2.1.0"
     }
+
     null = {
       source  = "hashicorp/null"
       version = "~> 3.1.0"
     }
+
     cloudinit = {
       source  = "hashicorp/cloudinit"
       version = "~> 2.2.0"


### PR DESCRIPTION
Updated required_providers block to remove duplicate AWS provider entries 
and upgraded AWS provider version to >= 5.40.0 for EKS module compatibility.